### PR TITLE
Address oddity with test fixtures

### DIFF
--- a/test/controllers/pseudonymisation_controller_test.rb
+++ b/test/controllers/pseudonymisation_controller_test.rb
@@ -4,7 +4,7 @@ class PseudonymisationControllerTest < ActionDispatch::IntegrationTest
   setup do
     @key1 = pseudonymisation_keys(:primary_one)
     @key2 = pseudonymisation_keys(:primary_two)
-    @rekey1 = pseudonymisation_keys(:repseudo_one)
+    @rekey1 = pseudonymisation_keys(:standalone_repseudo_one)
   end
 
   test 'should use granted keys and variants to pseudonymise when given just NHS / DoB / postcode' do
@@ -44,7 +44,7 @@ class PseudonymisationControllerTest < ActionDispatch::IntegrationTest
     input_pseudoid = 'd7bc8a726b8110b09765db5b151b999f34b9c269301e82af6ce1d349c847374b'
     post_with_params identifiers: { input_pseudoid: input_pseudoid }
     actual = response.parsed_body
-    expected = [{ 'key_name' => 'RePseudo Key One',
+    expected = [{ 'key_name' => 'Standalone RePseudo One',
                   'variant' => 3,
                   'identifiers' => { 'input_pseudoid' => input_pseudoid },
                   'context' => 'testing',

--- a/test/fixtures/key_grants.yml
+++ b/test/fixtures/key_grants.yml
@@ -4,4 +4,4 @@ grant_one:
 
 grant_two:
   user: test_user
-  pseudonymisation_key: repseudo_one
+  pseudonymisation_key: standalone_repseudo_one

--- a/test/fixtures/pseudonymisation_keys.yml
+++ b/test/fixtures/pseudonymisation_keys.yml
@@ -23,3 +23,9 @@ compound_one:
   name: Compound Key One
   start_key: primary_one
   end_key: repseudo_one
+
+standalone_repseudo_one:
+  key_type: compound
+  name: Standalone RePseudo One
+  start_key: repseudo_one
+  end_key: repseudo_one


### PR DESCRIPTION
### The issue

The application has codepaths for behaviour, which are covered by the test suite, to allow for `input_pseudoid` values to be re-pseudonymised as 3rd variant of key output.

The test coverage is facilitated by the existence of the following `KeyGrant` test fixture:

```yaml
grant_two:
  user: test_user
  pseudonymisation_key: repseudo_one 
```

However, that model's validation set would actually prevent such a row from being allowed into the database (fixture inserts do not run validations) - `KeyGrant#ensure_pseudonymisation_key_is_primary` prevent keys with a tagged "parent" being useable. This behaviour was added in b88f1dba.

### This pull request

This pull request adds a new compound key to the fixtures which wrap the original secondary re-pseudonymisation key, and switches the grant over to that. As direct granting of compound keys is allowed, this results in valid data being used.

### Alternatives

I cannot remember the original rationale for blocking the use of secondary pseudonymisation keys. The intention of compound keys `[CompoundKeyA] = [Key A] -> [ReKeyB]` was allow a user to make use of `input -> [Key A] -> [ReKey B] -> pseudoid` without being able to gain access to the intermediary pseudo ID. However, I don't think that automatically precludes the granting of use of `[ReKey B]` (a secondary key) in other circumstances.

It may therefore be that the `KeyGrant#ensure_pseudonymisation_key_is_primary` is outdated, and an alternate PR should remove that instead?