### PR TITLE
Remove constraint limiting grants to just primary pseudonymisation keys

### DIFF
--- a/app/models/key_grant.rb
+++ b/app/models/key_grant.rb
@@ -5,14 +5,4 @@ class KeyGrant < ApplicationRecord
   belongs_to :pseudonymisation_key
 
   validates :user, uniqueness: { scope: :pseudonymisation_key }
-
-  validate :ensure_pseudonymisation_key_is_primary
-
-  private
-
-  def ensure_pseudonymisation_key_is_primary
-    return if pseudonymisation_key.primary?
-
-    errors.add(:pseudonymisation_key, 'not a primary pseudo key')
-  end
 end

--- a/test/models/key_grant_test.rb
+++ b/test/models/key_grant_test.rb
@@ -14,20 +14,4 @@ class KeyGrantTest < ActiveSupport::TestCase
 
     assert_includes new_grant.user.pseudonymisation_keys, new_key
   end
-
-  test 'should only grant to primary pseudonymisation keys' do
-    grant = KeyGrant.new(user: users(:test_user))
-
-    grant.pseudonymisation_key = pseudonymisation_keys(:primary_two)
-    grant.valid?
-    refute_includes grant.errors.details[:pseudonymisation_key], error: 'not a primary pseudo key'
-
-    grant.pseudonymisation_key = pseudonymisation_keys(:repseudo_one)
-    grant.valid?
-    assert_includes grant.errors.details[:pseudonymisation_key], error: 'not a primary pseudo key'
-
-    grant.pseudonymisation_key = pseudonymisation_keys(:compound_one)
-    grant.valid?
-    refute_includes grant.errors.details[:pseudonymisation_key], error: 'not a primary pseudo key'
-  end
 end


### PR DESCRIPTION
Following on from the discussions on #4, it has been decided that it should be possible to grant use of secondary (i.e. repseudonymisation) keys directly, rather than needing to wrap them as a compound key.

This doesn't affect the ability to grant use of compound key comprising of a primary + second key chain, thus preventing the user accessing the intermediate pseudoid value.

This PR removes the validation and associated test case. As a result, the existing `KeyGrant` fixtures are now all valid (much of the test suite described behaviours reliant on being able to grant use of secondary keys, so this seems to have been an oversight originally).
